### PR TITLE
More fixes for compatibility with Arch Linux.

### DIFF
--- a/l2ork_addons/disis_munger/disis_munger.cpp
+++ b/l2ork_addons/disis_munger/disis_munger.cpp
@@ -32,6 +32,7 @@ For latest changes please see changelog
 #include <math.h>
 #include <time.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 //Unnecessary to include these two header file for this version
 //#include <stdlib.h>


### PR DESCRIPTION
On Arch, disis_munger still refused to compile because of a missing include. This changeset fixes that.
