### PR TITLE
Allow inst_dir variable of tar_em_up.sh to be overridden.

### DIFF
--- a/l2ork_addons/tar_em_up.sh
+++ b/l2ork_addons/tar_em_up.sh
@@ -30,7 +30,7 @@ full=0
 sys_cwiid=0
 rpi=0
 
-inst_dir=/usr/local
+inst_dir=${inst_dir:-/usr/local}
 
 while getopts ":abBcdefFRruw" Option
 do case $Option in


### PR DESCRIPTION
This change allows the inst_dir variable of the tar_me_up.sh script to be overridden from the command line. This is useful to adjust the installation prefix when this script is used to build packages for non-Debian systems.
