### PR TITLE
More fixes to the Debian packaging.

### DIFF
--- a/debuild/debian/postrm
+++ b/debuild/debian/postrm
@@ -1,5 +1,5 @@
 #!/bin/sh
-# postrm script for pure
+# postrm script for pd-l2ork
 #
 # see: dh_installdeb(1)
 
@@ -22,12 +22,7 @@ set -e
 case "$1" in
     purge|remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     if [ remove = "$1" -o abort-install = "$1" -o disappear = "$1" ]; then
-       for x in cyclist pdsend pdreceive; do
-	   dpkg-divert --package pd-l2ork --remove --rename --divert /usr/bin/$x.orig /usr/bin/$x
-       done
-       for x in pdsend pdreceive; do
-	   dpkg-divert --package pd-l2ork --remove --rename --divert /usr/share/man/man1/$x.1.orig.gz /usr/share/man/man1/$x.1.gz
-       done
+       dpkg-divert --package pd-l2ork --remove --rename --divert /usr/share/icons/hicolor/128x128/mimetypes/text-x-puredata.png.orig /usr/share/icons/hicolor/128x128/mimetypes/text-x-puredata.png
     fi
     ;;
 

--- a/debuild/debian/preinst
+++ b/debuild/debian/preinst
@@ -1,5 +1,5 @@
 #!/bin/sh
-# preinst script for pure
+# preinst script for pd-l2ork
 #
 # see: dh_installdeb(1)
 
@@ -16,12 +16,7 @@ set -e
 # Move files out of the way which are also in the vanilla Pd package.
 case "$1" in
     install|upgrade)
-    for x in cyclist pdsend pdreceive; do
-	dpkg-divert --package pd-l2ork --add --rename --divert /usr/bin/$x.orig /usr/bin/$x
-    done
-    for x in pdsend pdreceive; do
-	dpkg-divert --package pd-l2ork --add --rename --divert /usr/share/man/man1/$x.1.orig.gz /usr/share/man/man1/$x.1.gz
-    done
+    dpkg-divert --package pd-l2ork --add --rename --divert /usr/share/icons/hicolor/128x128/mimetypes/text-x-puredata.png.orig /usr/share/icons/hicolor/128x128/mimetypes/text-x-puredata.png
     ;;
 
     abort-upgrade)

--- a/debuild/debian/rules
+++ b/debuild/debian/rules
@@ -16,14 +16,19 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	mkdir -p debian/pd-l2ork && mv packages/linux_make/build/usr debian/pd-l2ork
+# Remove some unneeded files.
+	cd debian/pd-l2ork/ && rm -f Makefile README.txt
+	cd debian/pd-l2ork/usr/lib/pd-l2ork/extra && rm -rf */*.pd_linux_o */*.la
+# Remove cyclist and pdsend/pdreceive which are provided by other packages.
+	cd debian/pd-l2ork/usr/bin && rm -rf pdsend pdreceive cyclist
+	cd debian/pd-l2ork/usr/share/man/man1 && rm -rf pdsend.* pdreceive.*
+# Move the Gem include files into the pd-l2ork include directory to prevent
+# conflicts with other packages providing these files.
+	cd debian/pd-l2ork/usr && mv include/Gem include/pd-l2ork
+# Edit the Gem pkgconfig file accordingly and rename it.
+	cd debian/pd-l2ork/usr/lib/pkgconfig && sed -e 's?/include?/include/pd-l2ork?g' -e 's?/lib/pd/extra?/lib/pd-l2ork/extra?g' < Gem.pc > pd-l2ork-Gem.pc && rm -f Gem.pc
 # Default preferences file.
 	install -d debian/pd-l2ork/etc/pd-l2ork && ln -s -f /usr/lib/pd-l2ork/default.settings debian/pd-l2ork/etc/pd-l2ork/default.settings
-# Get rid of the Gem development files (these are provided elsewhere) and
-# other stuff that's neither needed nor wanted.
-	cd debian/pd-l2ork/ && rm -f Makefile README.txt
-	cd debian/pd-l2ork/usr && rm -rf include/Gem lib/pkgconfig lib/pd-l2ork/extra/*/*.pd_linux_o lib/pd-l2ork/extra/*/*.la
-# XXXTODO: Do we want to move these over to the doc hierarchy??
-#	rm -f debian/pd-l2ork/usr/lib/pd-l2ork/extra/*-help.pd
 
 # XXXTODO: This is deprecated, so we might have to migrate to dh_python2 in
 # the future. See http://deb.li/dhs2p.


### PR DESCRIPTION
As suggested, I removed pdsend, pdreceive and cyclist, and moved the Gem include files into /usr/include/pd-l2ork. The Gem.pc file is edited to reflect this and renamed to pd-l2ork-Gem.pc to avoid file conflicts with pd-extended. Also, I added a preinst/postrm rule to take care of /usr/share/icons/hicolor/128x128/mimetypes/text-x-puredata.png which is also in the pd-extended package. Both pd-extended and pd-l2ork install cleanly on the same system now.
