### PR TITLE
Fix broken submodules config.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,6 @@
 [submodule "externals/miXed"]
 	path = externals/miXed
 	url = https://github.com/pd-l2ork/miXed.git
-z
 [submodule "l2ork_addons/raspberry_pi/disis_gpio/wiringPi"]
 	path = l2ork_addons/raspberry_pi/disis_gpio/wiringPi
 	url = git://git.drogon.net/wiringPi


### PR DESCRIPTION
Fixes up the submodule config which apparently got hosed in commits ec05a90 and 498ff4a. Specifically, wiringPi is now correctly recognized as a submodule located at l2ork_addons/raspberry_pi/disis_gpio/wiringPi, and will be properly created and initialized with `git clone --recursive`, `git update --init`, etc. At least it works over here. :)