### PR TITLE
Update debuild after wiringPi is now a submodule.

### DIFF
--- a/debuild/Makefile
+++ b/debuild/Makefile
@@ -96,9 +96,6 @@ $(debsrc):
 	git -C .. archive --format=tar.gz --prefix=$(debdist)/ HEAD | tar xfz -
 # Grab the submodules.
 	for x in $(submodules); do (cd $(debdist) && rm -rf $$x && git -C ../../$$x archive --format=tar.gz --prefix=$$x/ HEAD | tar xfz -); done
-# Grab wiringPi. This isn't a submodule yet, so needs to be handled separately.
-	git -C $(debdist)/l2ork_addons/raspberry_pi/disis_gpio clone "git://git.drogon.net/wiringPi"
-	rm -rf $(debdist)/l2ork_addons/raspberry_pi/disis_gpio/wiringPi/.git
 # Create the source tarball.
 	tar cfz $(debsrc) $(debdist)
 	rm -rf $(debdist)

--- a/debuild/debian/changelog
+++ b/debuild/debian/changelog
@@ -1,3 +1,9 @@
+pd-l2ork (20160614+git1702-1) xenial; urgency=low
+
+  * Build from latest upstream source.
+
+ -- Albert Graef <aggraef@gmail.com>  Tue, 14 Jun 2016 15:13:43 +0200
+
 pd-l2ork (20160608+git1683-1) xenial; urgency=low
 
   * Build from latest upstream source.

--- a/debuild/debian/rules
+++ b/debuild/debian/rules
@@ -10,7 +10,6 @@
 override_dh_auto_configure:
 
 override_dh_auto_build:
-	cd l2ork_addons/raspberry_pi/disis_gpio/wiringPi/wiringPi && make static
 	cd l2ork_addons && inst_dir=/usr ./tar_em_up.sh -F -n
 
 override_dh_auto_install:


### PR DESCRIPTION
Removed some special magic in the debuild stuff which isn't needed any more. I already tested this locally. Launchpad is slow today, so I'm still waiting for my Trusty and Xenial test builds there, but I think that they will be be fine.