### PR TITLE
Autobuild fixes

### DIFF
--- a/debuild/debian/install
+++ b/debuild/debian/install
@@ -1,8 +1,0 @@
-scripts/bash_completion/pd-l2ork	etc/bash_completion.d
-l2ork_addons/K12			usr/lib/pd-l2ork/extra
-externals/hardware/arduino		usr/lib/pd-l2ork/extra
-packages/linux_make/default.settings	usr/lib/pd-l2ork
-packages/linux_make/pd-l2ork.gif	usr/lib/pd-l2ork
-packages/linux_make/pd-l2ork*.png	usr/share/icons/hicolor/128x128/apps
-packages/linux_make/text-x-pd-l2ork.png	usr/share/icons/hicolor/128x128/mimetypes
-packages/linux_make/pd-l2ork*.desktop	usr/share/applications

--- a/debuild/debian/rules
+++ b/debuild/debian/rules
@@ -10,10 +10,10 @@
 override_dh_auto_configure:
 
 override_dh_auto_build:
-	cd l2ork_addons && inst_dir=/usr ./tar_em_up.sh -F -n
+	cd l2ork_addons && ./tar_em_up.sh -B -n
 
 override_dh_auto_install:
-	mkdir -p debian/pd-l2ork && mv packages/linux_make/build/usr debian/pd-l2ork
+	mkdir -p debian/pd-l2ork && mv packages/linux_make/build/* debian/pd-l2ork
 # Remove some unneeded files.
 	cd debian/pd-l2ork/ && rm -f Makefile README.txt
 	cd debian/pd-l2ork/usr/lib/pd-l2ork/extra && rm -rf */*.pd_linux_o */*.la
@@ -27,8 +27,6 @@ override_dh_auto_install:
 	cd debian/pd-l2ork/usr && mv include/Gem include/pd-l2ork
 # Edit the Gem pkgconfig file accordingly and rename it.
 	cd debian/pd-l2ork/usr/lib/pkgconfig && sed -e 's?/include?/include/pd-l2ork?g' -e 's?/lib/pd/extra?/lib/pd-l2ork/extra?g' < Gem.pc > pd-l2ork-Gem.pc && rm -f Gem.pc
-# Default preferences file.
-	install -d debian/pd-l2ork/etc/pd-l2ork && ln -s -f /usr/lib/pd-l2ork/default.settings debian/pd-l2ork/etc/pd-l2ork/default.settings
 
 # NOTE: Older systems use dh_pysupport instead of dh_python2. See
 # http://deb.li/dhs2p.

--- a/l2ork_addons/tar_em_up.sh
+++ b/l2ork_addons/tar_em_up.sh
@@ -366,11 +366,11 @@ then
 	cd ../../
 	echo "done with l2ork addons."
 	cd ../
-	if [ $pkg -gt 0 ]; then
 	# finish install
 	cd packages/linux_make
-	echo "tar full installer..."
 	rm -f build/usr/local/lib/pd
+	if [ $pkg -gt 0 ]; then
+	echo "tar full installer..."
 	if [ $deb -gt 0 ]
 	then
 		cd build/
@@ -389,8 +389,10 @@ then
 		#mv build/Pd*bz2 ../../../Pd-l2ork-full-`uname -m`-`date +%Y%m%d`.tar.bz2
 		mv -f build/pd*bz2 ../../..
 	fi
-	cd ../../
+	elif [ $deb -gt 0 ]; then
+		make debstage prefix=$inst_dir
 	fi
+	cd ../../
 fi
 
 if [ $addon -eq 1 ]

--- a/packages/linux_make/Makefile
+++ b/packages/linux_make/Makefile
@@ -84,9 +84,8 @@ tarbz2: installer_settings installer_makefile installer_readme
 	mv $(DESTDIR)$(PACKAGE_NAME) $(DESTDIR)$(prefix)
 
 
-deb: DEB_BUILD_ARCH := $(shell dpkg-architecture -qDEB_BUILD_ARCH)
-deb: DEB_PD_VERSION := $(shell echo $(PD_VERSION) | sed 's|\(.*\)-l2ork-\(.*\)|\1-\2|')
-deb: $(bindir)
+# Any special staging for the "Burrito Supreme" installer goes here.
+debstage: $(bindir)
 # add K12 mode
 	cp -rf ../../l2ork_addons/K12/ $(DESTDIR)$(libpddir)/extra/
 # add arduino library
@@ -145,6 +144,10 @@ deb: $(bindir)
 # Pd-related scripts
 	#install -p $(scripts_src)/pd-diff $(DESTDIR)$(bindir)
 	#install -p $(scripts_src)/config-switcher.sh $(DESTDIR)$(bindir)
+
+deb: DEB_BUILD_ARCH := $(shell dpkg-architecture -qDEB_BUILD_ARCH)
+deb: DEB_PD_VERSION := $(shell echo $(PD_VERSION) | sed 's|\(.*\)-l2ork-\(.*\)|\1-\2|')
+deb: debstage
 # delete these since they are provided by the 'puredata-utils' and 'cyclist' packages
 	rm -f $(DESTDIR)$(bindir)/pdsend
 	rm -f $(DESTDIR)$(bindir)/pdreceive

--- a/packages/linux_make/Makefile
+++ b/packages/linux_make/Makefile
@@ -207,6 +207,7 @@ installer_makefile:
 #	-rm -f -- $(helpdir)/iem*/*\$$*.pd $(objectsdir)/iem*/*\$$*.pd
 # don't put the Makefile into the package yet, otherwise it'll get installed
 	cp -rf ../../l2ork_addons/K12/ $(DESTDIR)$(libpddir)/extra/
+	cp -rf ../../externals/hardware/arduino $(DESTDIR)$(libpddir)/extra/
 	cp -f $(packages_src)/linux_make/pd-l2ork.png $(DESTDIR)$(libpddir)
 	cp -f $(packages_src)/linux_make/pd-l2ork-red.png $(DESTDIR)$(libpddir)
 	cp -f $(packages_src)/linux_make/pd-l2ork-k12.png $(DESTDIR)$(libpddir)


### PR DESCRIPTION
This modifies `tar_em_up.sh -B -n` to add all the extra files of the Debian package to the staging area in `linux_make/build`, so that it can be used by 3rd party package maintainers on any kind of Linux system to build packages with exactly the same contents as the official Debian package created with `tar_em_up.sh -B`.

To these ends, the extra staging at the beginning of the `deb` target in `linux_make/Makefile` has been moved to a separate `debstage` target. The other targets of `tar_em_up` are unchanged. In particular, `tar_em_up.sh -B`, `-b`, `-F`, `-f` etc. will all work exactly as before.

In addition, the debuild packaging system build was adjusted to use `tar_em_up.sh -B -n` now. I also have an Arch PKGBUILD using `tar_em_up.sh -B -n` ready to be submitted to the Arch User Repositories once this is merged.

Finally, `linux_make/Makefile` was modified to add the missing arduino folder to the tarball package (`tar_em_up.sh -F`).

Tested on Ubuntu and Arch by comparing the package contents of `tar_em_up.sh -B`, `tar_em_up.sh -F` and the Arch package before and after this changeset, as well as Launchpad debuild test builds for both Trusty (14.04) and Xenial (16.04). All looking good, so this is ready to be merged.