### PR TITLE
Arch fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/pd-l2ork/miXed.git
 [submodule "l2ork_addons/raspberry_pi/disis_gpio/wiringPi"]
 	path = l2ork_addons/raspberry_pi/disis_gpio/wiringPi
-	url = git://git.drogon.net/wiringPi
+	url = https://git.purrdata.net/jwilkes/wiringPi.git

--- a/externals/OSCx/src/Makefile
+++ b/externals/OSCx/src/Makefile
@@ -21,7 +21,7 @@ LIBS = -lc -lm
 LIBOSC = ../libOSC/libOSC.a
 
 CFLAGS = -g -O2 -DUNIX -Wall -Wimplicit -Wunused -Wmissing-prototypes -O2 -fPIC -I../libOSC -I../../pd/src -I../../../pd/src -I../src
-INCLUDES = -I../libOSC -I../../pd/src -I../../../pd/src -I../src
+INCLUDES = -I../libOSC -I../../pd/src -I../../../pd/src -I../src -I/usr/include/tirpc
 LDFLAGS = -Wl,--export-dynamic -shared
 
 prefix=/usr/local

--- a/externals/OSCx/src/Makefile.in
+++ b/externals/OSCx/src/Makefile.in
@@ -21,7 +21,7 @@ LIBS = @LIBS@
 LIBOSC = ../libOSC/@LIBOSC@
 
 CFLAGS = @CFLAGS@
-INCLUDES = @INCLUDES@
+INCLUDES = @INCLUDES@ -I/usr/include/tirpc
 LDFLAGS = @LDFLAGS@
 
 prefix=@prefix@

--- a/l2ork_addons/tar_em_up.sh
+++ b/l2ork_addons/tar_em_up.sh
@@ -15,6 +15,7 @@ then
 	echo "     -e    everything"
 	echo "     -f    full installer (incremental)"
 	echo "     -F    full installer (complete recompile)"
+	echo "     -k    enable IEM font kludges (automatic on Ubuntu)"
 	echo "     -n    skip package creation (-bB, -fF)"
 	echo "     -R    build a Raspberry Pi deb (complete recompile)"
 	echo "     -r    build a Raspberry Pi deb (incremental)"
@@ -36,10 +37,11 @@ full=0
 sys_cwiid=0
 rpi=0
 pkg=1
+font_kludge=0
 
 inst_dir=${inst_dir:-/usr/local}
 
-while getopts ":abBcdefFnRruw" Option
+while getopts ":abBcdefFknRruw" Option
 do case $Option in
 		a)		addon=1;;
 
@@ -61,6 +63,8 @@ do case $Option in
 		f)		full=1;;
 
 		F)		full=2;;
+
+		k)		font_kludge=1;;
 
 		n)		pkg=0;;
 
@@ -174,6 +178,10 @@ requires internet connection to pull sources from various repositories..."
 			#echo "no fix needed"
         		cp pd/src/g_all_guis.c.default pd/src/g_all_guis.c
 		fi
+	elif [ $font_kludge -gt 0 ]
+	then
+		#echo "undetected system, need a fix anyway"
+		cp pd/src/g_all_guis.c.ubuntu.18 pd/src/g_all_guis.c
 	else
 		#echo "non Ubuntu distro detected, using default"
         	cp pd/src/g_all_guis.c.default pd/src/g_all_guis.c

--- a/pd/src/pd.tk
+++ b/pd/src/pd.tk
@@ -7228,7 +7228,7 @@ proc fit_font_into_metrics {} {
             [font metrics $myfont -linespace] > $height} {
             incr height2 -1
             font configure $myfont -size [expr {-$height2}]
-            if {$height2 * 2 <= $height} {
+            if {$height2 * 3 <= $height} {
                 set giveup 1
                 set ::font_measured_metrics $::font_fixed_metrics
                 break

--- a/pd/src/pd.tk
+++ b/pd/src/pd.tk
@@ -7238,7 +7238,7 @@ proc fit_font_into_metrics {} {
             "$::font_measured_metrics  $size\
                 [font measure $myfont M] [font metrics $myfont -linespace]"
         if {$giveup} {
-            ::pdwindow::post [format \
+            pdtk_post [format \
     [_ "WARNING: %s failed to find font size (%s) that fits into %sx%s!\n"]\
                [lindex [info level 0] 0] $size $width $height]
             continue


### PR DESCRIPTION
Some fixes to make pd-l2ork compile and run on Arch again. Fixes #50.

- Rev. 53f652b1a67454f58133a786dc9488106fb1438e points the wiringPi submodule to Jonathan's mirror at https://git.purrdata.net/jwilkes/wiringPi.git. It seems that git://git.drogon.net/wiringPi is permanently offline, preventing the submodule from checking out.

- Rev. e5880772446f2dc6b8817cd6be6e4ae215ff3e68 pulls over a fix from purr-data which makes OSCx compile on systems with newer (>= 2018) libc versions which don't have rpc/rpc.h any more; this change only adds an include path so that the module will compile if libtirpc is installed instead, and won't affect older systems.

- Rev. b48b1fdf3bfea1dd4f4d792512e52dc3f82a0490 fixes a nonexistant `::pdwindow::post` call that's supposed to report font scaling issues during startup. (I actually ran into these, see below.) Easily fixed by calling `pdtk_post` instead.

-  Rev. ecca59b648cc5086fcd2165ae4cd499b7b4e0e68 makes an attempt to fix font scaling on high-dpi displays with dpi set to > 96 dpi. Specifically on my system with a font dpi setting of 120 I found that `fit_font_into_metrics` wouldn't be able to find suitable font sizes to match the prescribed font metrics. Simply increasing the maximum scaling factor there from 2 to 3 fixed the issue for me. The base fonts then look all right, although the IEM GUI font sizes are still way too large. Screenie:

![image](https://user-images.githubusercontent.com/2853977/62799660-afb82680-bae1-11e9-8182-634afbb9c984.png)

The larger IEM font sizes remain the same in relation to the base fonts no matter what dpi setting I choose. I suspect that there are some hardcoded font sizes there which just don't match up on modern systems any more. Any hints on how one might go about fixing these?