### PR TITLE
Fix zexy-meta.pd so that it doesn't throw off the help browser

### DIFF
--- a/externals/zexy/zexy-meta.pd.in
+++ b/externals/zexy/zexy-meta.pd.in
@@ -188,7 +188,7 @@ the type;
 #X obj 28 229 index;
 #X msg 28 207 help;
 #X text 202 226 map symbols to indices;
-#X text 166 384 (no "help"-message available...);
+#X text 166 384 (no "help" message available...);
 #X obj 28 433 demultiplex;
 #X obj 128 433 demux;
 #X text 109 434 ==;


### PR DESCRIPTION
You can reproduce this error as follows: Launch pd-l2ork from a terminal, invoke the help browser (Ctrl+B), then click on the `External Pd libraries` link. You'll see the following error message in the terminal:

~~~
tcl error: list element in quotes followed by "-message" instead of space
    while executing
"join $file_contents"
    (procedure "::dialog_search::print_libdirs" line 22)
    invoked from within
"::dialog_search::print_libdirs $textwidget $libdirs"
    (procedure "::dialog_search::build_libdirs" line 19)
    invoked from within
"::dialog_search::build_libdirs  .search.resultstext"
    (command bound to event)
~~~

This results in the entry for zexy looking like this in the help browser (at the very bottom of the "External libraries" page):

![image](https://user-images.githubusercontent.com/2853977/62824435-d3d93d80-bb9d-11e9-9799-bbf2ce92f5f4.png)

Looking at the code of `print_libdirs` in search-plugin.tcl:1442, the culprit is the `join` call in this line:

~~~tcl
regexp -nocase -- "#X text \[0-9\]+ \[0-9\]+ description\[:\]? (.*?);.*" [join $file_contents] -> description
~~~

The zexy-meta.pd file contains this line which causes the issue:

~~~
#X text 166 384 (no "help"-message available...);
~~~

Obviously the `join` command misinterprets the `-message` string there as a command option which it doesn't want there, hence the cryptic error message. (Who thinks that "everything is just text" makes for a good programming language design, haha.)

Just replacing the dash with a space solves the issue (looks better anyway I'd say, and hopefully IOhannes won't mind that little change). No error message from the browser any more and the zexy entry now looks sane:

![image](https://user-images.githubusercontent.com/2853977/62824480-d8522600-bb9e-11e9-95b6-98bedacb2136.png)

So this PR modifies the zexy-meta.pd file in the manner described above, so that it doesn't throw off the help browser's `print_libdirs` routine any more. I'm sure that there's a clever and robust way to resolve this in the Tcl code itself, but I don't know it, and this works for me. If anyone has a brighter idea how to solve this, then please do...