### PR TITLE
Debuild fixes

### DIFF
--- a/debuild/Makefile
+++ b/debuild/Makefile
@@ -63,7 +63,7 @@ debchange:
 
 debclean:
 	rm -rf $(debdist)
-	rm -f pd-l2ork_*+git*
+	rm -f pd-l2ork_*+git* pd-l2ork-dbgsym_*+git*
 
 deb: $(debsrc)
 # Unpack the source into our temporary build directory.

--- a/debuild/debian/rules
+++ b/debuild/debian/rules
@@ -4,13 +4,19 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+ifeq ("$(shell dpkg-architecture -qDEB_HOST_ARCH)","armhf")
+buildopt = -R
+else
+buildopt = -B
+endif
+
 %:
 	dh $@
 
 override_dh_auto_configure:
 
 override_dh_auto_build:
-	cd l2ork_addons && ./tar_em_up.sh -B -n
+	cd l2ork_addons && ./tar_em_up.sh $(buildopt) -n
 
 override_dh_auto_install:
 	mkdir -p debian/pd-l2ork && mv packages/linux_make/build/* debian/pd-l2ork


### PR DESCRIPTION
- Makes `make debclean` work properly (didn't remove debug packages).

- Adds the proper tar_em_up.sh build flag `-R` for compilation on the armfh architecture, so that debuild builds on that platform (e.g., Raspbian) will now work properly. This fixes #54.