### PR TITLE
Switch to the latest Gem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Gem"]
 	path = Gem
-	url = git://git.code.sf.net/p/pd-gem/gem
+	url = https://git.purrdata.net/aggraef/gem.git
 [submodule "l2ork_addons/rtcmix-in-pd"]
 	path = l2ork_addons/rtcmix-in-pd
 	url = https://github.com/jwmatthys/rtcmix-in-pd.git


### PR DESCRIPTION
As discussed previously in https://github.com/pd-l2ork/pd/pull/51#issuecomment-520053311. Note that this changes the Gem submodule URL *and* hash to https://git.purrdata.net/aggraef/gem/tree/gem-fixes, which has all the latest fixes, and is also what we're using in purr-data now. In particular, video playback works properly again (fixing https://github.com/umlaeute/Gem/issues/233). Tested on Ubuntu 19.04, Arch and Ubuntu packages will become available later today.