### PR TITLE
gcc 10 fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "Gem"]
 	path = Gem
 	url = https://git.purrdata.net/aggraef/gem.git
+[submodule "l2ork_addons/raspberry_pi/disis_gpio/wiringPi"]
+	path = l2ork_addons/raspberry_pi/disis_gpio/wiringPi
+	url = https://git.purrdata.net/jwilkes/wiringPi.git

--- a/externals/iem/iem_adaptfilt/src/iemlib.h
+++ b/externals/iem/iem_adaptfilt/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iem_ambi/src/iemlib.h
+++ b/externals/iem/iem_ambi/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iem_bin_ambi/src/iemlib.h
+++ b/externals/iem/iem_bin_ambi/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iem_delay/src/iemlib.h
+++ b/externals/iem/iem_delay/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iem_roomsim/src/iemlib.h
+++ b/externals/iem/iem_roomsim/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iem_spec2/src/iemlib.h
+++ b/externals/iem/iem_spec2/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iem_tab/src/iemlib.h
+++ b/externals/iem/iem_tab/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/externals/iem/iemgui/src/iemlib.h
+++ b/externals/iem/iemgui/src/iemlib.h
@@ -22,11 +22,11 @@ iemlib written by Thomas Musil, Copyright (c) IEM KUG Graz Austria 2000 - 2009 *
  */
 
 #ifdef MSW
-int sys_noloadbang;
+//int sys_noloadbang;
 //t_symbol *iemgui_key_sym=0;
 #include <io.h>
 #else
-extern int sys_noloadbang;
+//extern int sys_noloadbang;
 //extern t_symbol *iemgui_key_sym;
 #include <unistd.h>
 #endif

--- a/l2ork_addons/raspberry_pi/disis_gpio/build.sh
+++ b/l2ork_addons/raspberry_pi/disis_gpio/build.sh
@@ -1,7 +1,5 @@
 curdir=`pwd`
-cd wiringPi/
-git reset --hard 96344ff7125182989f98d3be8d111952a8f74e15
-cd wiringPi/ && make static
+cd wiringPi/ && cd wiringPi/ && make static
 cd $curdir
 make
 exit 0

--- a/l2ork_addons/tar_em_up.sh
+++ b/l2ork_addons/tar_em_up.sh
@@ -363,8 +363,8 @@ requires internet connection to pull sources from various repositories..."
 	# copy rjlib into the extra folder
 	cp -rf rjlib ../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
 	# install raspberry pi externals (if applicable)
-	if [ $rpi -eq 1 ]
-	then
+	#if [ $rpi -eq 1 ]
+	#then
 		cd raspberry_pi
 		./makeall.sh
 		cp -f disis_gpio/disis_gpio.pd_linux ../../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
@@ -372,7 +372,7 @@ requires internet connection to pull sources from various repositories..."
 		cp -f disis_spi/disis_spi.pd_linux ../../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
 		cp -f disis_spi/disis_spi-help.pd ../../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
 		cd ../
-	fi
+	#fi
 	# install rtcmix~ external
 	#cd rtcmix-in-pd/
 	#git submodule update

--- a/l2ork_addons/tar_em_up.sh
+++ b/l2ork_addons/tar_em_up.sh
@@ -363,8 +363,8 @@ requires internet connection to pull sources from various repositories..."
 	# copy rjlib into the extra folder
 	cp -rf rjlib ../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
 	# install raspberry pi externals (if applicable)
-	#if [ $rpi -eq 1 ]
-	#then
+	if [ $rpi -eq 1 ]
+	then
 		cd raspberry_pi
 		./makeall.sh
 		cp -f disis_gpio/disis_gpio.pd_linux ../../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
@@ -372,7 +372,7 @@ requires internet connection to pull sources from various repositories..."
 		cp -f disis_spi/disis_spi.pd_linux ../../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
 		cp -f disis_spi/disis_spi-help.pd ../../packages/linux_make/build$inst_dir/lib/pd-l2ork/extra
 		cd ../
-	#fi
+	fi
 	# install rtcmix~ external
 	#cd rtcmix-in-pd/
 	#git submodule update

--- a/pd/src/g_canvas.c
+++ b/pd/src/g_canvas.c
@@ -47,6 +47,13 @@ t_canvas *canvas_editing;           /* last canvas to start text edting */
 t_canvas *canvas_whichfind;         /* last canvas we did a find in */ 
 //t_canvas *canvas_list;              /* list of all root canvases */
 
+// Ico, please review: I'm not sure whether these belong here, but they need
+// to be defined somewhere (in a .c file, not .h!!)
+t_garray* array_garray;
+t_class *preset_hub_class;
+t_class *preset_node_class;
+int array_joc;
+
 /* ------------------ forward function declarations --------------- */
 static void canvas_start_dsp(void);
 static void canvas_stop_dsp(void);

--- a/pd/src/g_canvas.h
+++ b/pd/src/g_canvas.h
@@ -151,7 +151,7 @@ typedef struct _arrayvis
     t_garray *av_garray;            /* owning structure */    
 } t_arrayvis;
 
-t_garray* array_garray;				/* used for sending bangs when
+EXTERN t_garray* array_garray;				/* used for sending bangs when
 									   array is changed  via gui */
 
 /* the t_tick structure describes where to draw x and y "ticks" for a glist */
@@ -235,8 +235,8 @@ struct _glist
 // this is where all the classes capable of being controlled via preset should be defined
 
 // preset objects
-t_class *preset_hub_class;
-t_class *preset_node_class;
+EXTERN t_class *preset_hub_class;
+EXTERN t_class *preset_node_class;
 
 // special case objects
 extern t_class *print_class;
@@ -632,7 +632,7 @@ EXTERN void array_resize(t_array *x, int n);
 EXTERN void array_free(t_array *x);
 EXTERN void array_redraw(t_array *a, t_glist *glist);
 EXTERN void array_resize_and_redraw(t_array *array, t_glist *glist, int n);
-int array_joc; /* for "jump on click" array inside a graph */
+EXTERN int array_joc; /* for "jump on click" array inside a graph */
 
 /* --------------------- gpointers and stubs ---------------- */
 EXTERN t_gstub *gstub_new(t_glist *gl, t_array *a);

--- a/pd/src/s_audio_mmio.c
+++ b/pd/src/s_audio_mmio.c
@@ -32,7 +32,6 @@ int nt_realdacblksize;
 #define MAXBUFFER 100   /* number of buffers in use at maximum advance */
 #define DEFBUFFER 30    /* default is about 30x6 = 180 msec! */
 static int nt_naudiobuffer = DEFBUFFER;
-float sys_dacsr = DEFAULTSRATE;
 
 static int nt_whichapi = API_MMIO;
 static int nt_meters;        /* true if we're metering */
@@ -127,6 +126,8 @@ int mmio_do_open_audio(void)
     if (sys_verbose)
         post("%d devices in, %d devices out",
             nt_nwavein, nt_nwaveout);
+
+    if (sys_dacsr == 0) sys_dacsr = DEFAULTSRATE;
 
     form.wf.wFormatTag = WAVE_FORMAT_PCM;
     form.wf.nChannels = CHANNELS_PER_DEVICE;
@@ -485,11 +486,6 @@ void nt_logerror(int which)
     }
 #endif
 }
-
-/* system buffer with t_sample types for one tick */
-t_sample *sys_soundout;
-t_sample *sys_soundin;
-float sys_dacsr;
 
 int mmio_send_dacs(void)
 {

--- a/pd/src/s_audio_oss.c
+++ b/pd/src/s_audio_oss.c
@@ -70,11 +70,6 @@ static t_oss_dev linux_adcs[OSS_MAXDEV];
 static int linux_noutdevs = 0;
 static int linux_nindevs = 0;
 
-    /* exported variables */
-t_float sys_dacsr;
-t_sample *sys_soundout;
-t_sample *sys_soundin;
-
     /* OSS-specific private variables */
 static int oss_blockmode = 1;   /* flag to use "blockmode"  */
 static char ossdsp[] = "/dev/dsp%d"; 

--- a/pd/src/s_path.c
+++ b/pd/src/s_path.c
@@ -43,6 +43,7 @@ t_namelist *sys_searchpath;
 t_namelist *sys_staticpath;
 t_namelist *sys_helppath;
 
+t_namelist *pd_extrapath;
 
     /* change '/' characters to the system's native file separator */
 void sys_bashfilename(const char *from, char *to)

--- a/pd/src/s_stuff.h
+++ b/pd/src/s_stuff.h
@@ -18,7 +18,7 @@ typedef struct _namelist    /* element in a linked list of stored strings */
     char *nl_string;            /* the string */
 } t_namelist;
 
-t_namelist *pd_extrapath;
+extern t_namelist *pd_extrapath;
 t_namelist *namelist_append(t_namelist *listwas, const char *s, int allowdup);
 t_namelist *namelist_append_files(t_namelist *listwas, const char *s);
 void namelist_free(t_namelist *listwas);


### PR DESCRIPTION
Fixes #59. Also repaired the missing wiringPi submodule, so that building didis_gpio works again. Tested via the OBS on 14 different Linux systems, including Arch, Debian/Ubuntu, and openSUSE, so I'd say that we can be pretty sure that it works almost everywhere.

The only system which still gives me trouble right now is Debian Unstable, but that's a build dependency issue with the Debian packaging tools, so it's unrelated. I have the same issue with purr-data, so I will get it sorted some time, but that's for another day.

Please review and merge asap, as I have more interesting things coming up, and subsequent pull request will be based on this one.